### PR TITLE
swagger 설정 및 config파일 수정, Travel검색기능 추가 

### DIFF
--- a/src/main/java/com/core/toy3/common/config/SwaggerConfig.java
+++ b/src/main/java/com/core/toy3/common/config/SwaggerConfig.java
@@ -18,21 +18,52 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-    String[] paths = {"/travel", "/trip"};
+    String root = "com.core.toy3.src";
+    String[] paths = {
+            ".travel.controller",
+            ".trip.controller",
+            ".member.controller",
+            ".comment.controller",
+            ".like.controller"
+    };
 
     @Bean
-    public GroupedOpenApi getTravelApi() {
+    public GroupedOpenApi getEntireApi() {
         return GroupedOpenApi.builder()
-                .group("travel")
-                .pathsToMatch(paths[0] + "/**")
+                .group("entire")
+                .packagesToScan(root)
                 .build();
     }
 
     @Bean
-    public GroupedOpenApi getTripApi() {
+    public GroupedOpenApi getTravelApi() {
         return GroupedOpenApi.builder()
-                .group("trip")
-                .pathsToMatch(paths[1] + "/**")
+                .group("travel & Trip")
+                .packagesToScan(root + paths[0], root + paths[1])
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi getMemberApi() {
+        return GroupedOpenApi.builder()
+                .group("member")
+                .packagesToScan(root + paths[2])
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi getCommentApi() {
+        return GroupedOpenApi.builder()
+                .group("comment")
+                .packagesToScan(root + paths[3])
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi getLikeApi() {
+        return GroupedOpenApi.builder()
+                .group("like")
+                .packagesToScan(root + paths[4])
                 .build();
     }
 }

--- a/src/main/java/com/core/toy3/src/travel/controller/TravelController.java
+++ b/src/main/java/com/core/toy3/src/travel/controller/TravelController.java
@@ -1,8 +1,6 @@
 package com.core.toy3.src.travel.controller;
 
-import com.core.toy3.common.exception.CustomException;
 import com.core.toy3.common.response.Response;
-import com.core.toy3.common.response.ResponseStatus;
 import com.core.toy3.src.member.entity.AuthMember;
 import com.core.toy3.src.travel.model.request.TravelRequest;
 import com.core.toy3.src.travel.model.response.TravelResponse;
@@ -12,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -42,6 +41,56 @@ public class TravelController {
 
         return Response.response(travelService.selectTravel(id));
     }
+
+    @GetMapping("/read/search")
+    public Response<List<TravelResponse>> searchTravel(
+            @RequestParam(value = "travelName", required = false) String travelName,
+            @RequestParam(value = "departure", required = false) String departure,
+            @RequestParam(value = "arrival", required = false) String arrival) {
+
+        List<TravelResponse> travelSearchList = travelService.getAllravel(); // 검색 안할경우 전체 리스트 출력
+
+        if (travelName != null && !travelName.trim().isEmpty()) {
+            System.out.println("travelName = " + travelName);
+            travelSearchList = travelService.SearchTravelByTravelName(travelName);
+        }
+
+        if (departure != null && !departure.trim().isEmpty()) {
+            System.out.println("departure = " + departure);
+            travelSearchList = travelService.SearchTravelByDeparture(departure);
+        }
+
+        if (arrival != null && !arrival.trim().isEmpty()) {
+            System.out.println("arrival = " + arrival);
+            travelSearchList = travelService.SearchTravelByArrival(arrival);
+        }
+
+        return Response.response(travelSearchList);
+    }
+
+//    @GetMapping("/read/search")
+//    public Response<List<TravelResponse>> SearchTravelByTravelName(@RequestParam(value = "travelName") String keyword) {
+//
+//        List<TravelResponse> travelSearchList = travelService.SearchTravelByTravelName(keyword);
+//
+//        return Response.response(travelSearchList);
+//    }
+//
+//    @GetMapping("/read/search")
+//    public Response<List<TravelResponse>> SearchTravelByDeparture(@RequestParam(value = "departure") String keyword) {
+//
+//        List<TravelResponse> travelSearchList = travelService.SearchTravelByDeparture(keyword);
+//
+//        return Response.response(travelSearchList);
+//    }
+//
+//    @GetMapping("/read/search")
+//    public Response<List<TravelResponse>> SearchTravelByArrival(@RequestParam(value = "arrival") String keyword) {
+//
+//        List<TravelResponse> travelSearchList = travelService.SearchTravelByArrival(keyword);
+//
+//        return Response.response(travelSearchList);
+//    }
 
     @PutMapping("/update-travel/{travelId}") // 1
     public Response<TravelResponse> updateTravel(

--- a/src/main/java/com/core/toy3/src/travel/repository/TravelRepository.java
+++ b/src/main/java/com/core/toy3/src/travel/repository/TravelRepository.java
@@ -48,5 +48,36 @@ public interface TravelRepository extends JpaRepository<Travel, Long> {
             where tv.id = :travel_id
             """)
     Optional<Travel> findTravel(@Param("travel_id") Long id);
+
+    @Query("""
+            select tv
+            from Travel tv
+            left join fetch tv.trip t
+            where (t is null or t.state = 'ACTIVE')
+            and trim(tv.travelName) like concat('%',:keyword, '%')
+            order by tv.id asc, t.postedAt asc
+            """)
+    List<Travel> getTravelSearchByTravelName(@Param("keyword") String keyword);
+
+    @Query("""
+            select tv
+            from Travel tv
+            left join fetch tv.trip t
+            where (t is null or t.state = 'ACTIVE')
+            and trim(tv.departure) like concat('%',:keyword, '%')
+            order by tv.id asc, t.postedAt asc
+            """)
+
+    List<Travel> getTravelSearchByDeparture(@Param("keyword") String keyword);
+
+    @Query("""
+            select tv
+            from Travel tv
+            left join fetch tv.trip t
+            where (t is null or t.state = 'ACTIVE')
+            and trim(tv.arrival) like concat('%',:keyword, '%')
+            order by tv.id asc, t.postedAt asc
+            """)
+    List<Travel> getTravelSearchByArrival(@Param("keyword") String keyword);
 }
 

--- a/src/main/java/com/core/toy3/src/travel/service/TravelService.java
+++ b/src/main/java/com/core/toy3/src/travel/service/TravelService.java
@@ -15,10 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import com.core.toy3.common.exception.CustomException;
-import com.core.toy3.src.travel.model.request.TravelRequest;
-import lombok.RequiredArgsConstructor;
-import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 import static com.core.toy3.common.response.ResponseStatus.*;
 
@@ -90,6 +86,37 @@ public class TravelService {
         return TravelResponse.toResult(travel);
     }
 
+    // travelName 기준으로 검색
+    @Transactional
+    public List<TravelResponse> SearchTravelByTravelName(String keyword) {
+
+        List<Travel> travelSearchByTravelName =
+                travelRepository.getTravelSearchByTravelName(keyword);
+        return travelSearchByTravelName
+                .stream()
+                .map(TravelResponse::toResult).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<TravelResponse> SearchTravelByDeparture(String keyword) {
+
+        List<Travel> travelSearchByTravelName =
+                travelRepository.getTravelSearchByDeparture(keyword);
+        return travelSearchByTravelName
+                .stream()
+                .map(TravelResponse::toResult).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<TravelResponse> SearchTravelByArrival(String keyword) {
+
+        List<Travel> travelSearchByTravelName =
+                travelRepository.getTravelSearchByArrival(keyword);
+        return travelSearchByTravelName
+                .stream()
+                .map(TravelResponse::toResult).collect(Collectors.toList());
+    }
+
     @Transactional
     public TravelResponse updateTravel(long id, TravelRequest travelRequest, AuthMember member) {
 
@@ -123,6 +150,7 @@ public class TravelService {
                 .orElse(null);
     }
 
+    // 게시물의 주인이 다른 경우 예외 발생(수정, 삭제)
     private void validateMatches(AuthMember member, Travel travel) {
         if(travel.getMember().getId() != member.getId()) {
             throw new CustomException(HAS_NOT_PERMISSION_TO_ACCESS);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,9 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   swagger-ui:
-    operations-sorter: alpha
     tags-sorter: alpha
+    groups-order: desc
+    operations-sorter: method
     path: /swagger-ui
     disable-swagger-default-url: true
     display-request-duration: true


### PR DESCRIPTION
- 검색기능분류 : travelName, departure, arrival 기준(공백제외, 핸들러에 따라 검색, 검색어 없을시 전체 데이터 조회 -> 검색 키워드는 클라이언트에서 조정)
- swagger 설정 : 패키지에 따라 도메인별로 수정, Travel, trip의 경우 연관성이 강하므로 같은 분류로 묶음